### PR TITLE
Bugfixes in Sqlite3 adapter

### DIFF
--- a/src/adapter/Sqlite3.cpp
+++ b/src/adapter/Sqlite3.cpp
@@ -380,6 +380,11 @@ Dbpp::Connection open(const std::filesystem::path& file) {
 return open(file, OpenMode::ReadWriteCreate, OpenFlag::None);
 }
 
+void backup(Dbpp::Connection &db, const std::filesystem::path &file, int pagesPerStep, int sleepTimePerStepMs) {
+    auto progressFuncNoOp = [](int, int){};
+    backup(db, file, pagesPerStep, sleepTimePerStepMs, progressFuncNoOp);
+}
+
 void backup(Dbpp::Connection& db, const std::filesystem::path& file, int pagesPerStep, int sleepTimePerStepMs, std::function<void(int,int)> progressCallback) {
     if (db.adapterName() != "sqlite3")
         throw Error("dbpp::sqlite3::backup() can only be called with an sqlite3 connection");

--- a/src/adapter/Sqlite3.cpp
+++ b/src/adapter/Sqlite3.cpp
@@ -175,9 +175,9 @@ public:
 
     bool isNull(int index) const override {
         if (index < 0 || index >= colInfo_->numCols)
-            throw std::runtime_error("Column index out of bounds");
+            throw Error("Column index out of bounds");
         if (empty())
-            throw std::runtime_error("Attempted column access in empty result");
+            throw Error("Attempted column access in empty result");
         return sqlite3_column_type(stmt_.get(), index) == SQLITE_NULL;
     }
 


### PR DESCRIPTION
It threw std::runtime_error instead of Error in Sqlite3::result::isNull()
The version of backup() that doesn't take a progress callback was not implemented